### PR TITLE
Fix use of Query->criterion for filter

### DIFF
--- a/Command/AgeContentCommand.php
+++ b/Command/AgeContentCommand.php
@@ -68,7 +68,7 @@ class AgeContentCommand extends ContainerAwareCommand {
     protected function loadContentObjects($contentTypeName)
     {
         $query = new Query();
-        $query->criterion = new Query\Criterion\ContentTypeIdentifier($contentTypeName);
+        $query->filter = new Query\Criterion\ContentTypeIdentifier($contentTypeName);
 
         $searchResult = $this->getSearchService()->findContent($query);
         $contentsToFind = array();

--- a/Command/CreateTranslationsCommand.php
+++ b/Command/CreateTranslationsCommand.php
@@ -94,7 +94,7 @@ class CreateTranslationsCommand extends ContainerAwareCommand {
     protected function loadContentObjects($contentTypeName)
     {
         $query = new Query();
-        $query->criterion = new Query\Criterion\ContentTypeIdentifier($contentTypeName);
+        $query->filter = new Query\Criterion\ContentTypeIdentifier($contentTypeName);
 
         $searchResult = $this->getSearchService()->findContent($query);
         $contentsToFind = array();

--- a/Command/PerformanceListCommand.php
+++ b/Command/PerformanceListCommand.php
@@ -84,9 +84,9 @@ class PerformanceListCommand extends ContainerAwareCommand {
 
         // set average to each
         foreach($resultSet as $result) {
-            $result->setMinPercentage(round($result->getMin()/$minimumArray['min']*100,2));
-            $result->setMaxPercentage(round($result->getMax()/$minimumArray['max']*100,2));
-            $result->setAvgPercentage(round($result->getAvg()/$minimumArray['avg']*100,2));
+            $result->setMinPercentage(empty($minimumArray['min']) ? 0 : round($result->getMin()/$minimumArray['min']*100,2));
+            $result->setMaxPercentage(empty($minimumArray['max']) ? 0 : round($result->getMax()/$minimumArray['max']*100,2));
+            $result->setAvgPercentage(empty($minimumArray['avg']) ? 0 : round($result->getAvg()/$minimumArray['avg']*100,2));
         }
 
 

--- a/Command/PerformanceListCommand.php
+++ b/Command/PerformanceListCommand.php
@@ -23,6 +23,7 @@ class PerformanceListCommand extends ContainerAwareCommand {
     const ARGUMENT_CONTENT_TYPE = 'ctype';
     const OPTION_ITERATIONS = 'iterations';
     const OUTPUT_OPTIONS = 'show_min_max';
+    const OPTION_USER = 'as_user';
 
     /**
      * Configure command
@@ -34,6 +35,7 @@ class PerformanceListCommand extends ContainerAwareCommand {
         $this->addArgument(self::ARGUMENT_CONTENT_TYPE, null, 'eZ Content Type');
         $this->addOption(self::OPTION_ITERATIONS, 'iter', InputOption::VALUE_OPTIONAL, 'Amount of content objects to load and measure', 100);
         $this->addOption(self::OUTPUT_OPTIONS, 'minmax', InputOption::VALUE_OPTIONAL, 'Should min / max values be shown', 0);
+        $this->addOption(self::OPTION_USER, 'user', InputOption::VALUE_OPTIONAL, 'User ID to run tests with', 0);
     }
 
     /**
@@ -47,8 +49,9 @@ class PerformanceListCommand extends ContainerAwareCommand {
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $type = $input->getArgument(self::ARGUMENT_CONTENT_TYPE);
-        $iterations = $input->getOption(self::OPTION_ITERATIONS);
+        $iterations = (int)$input->getOption(self::OPTION_ITERATIONS);
         $showMinMax = $input->getOption(self::OUTPUT_OPTIONS);
+        $userId = (int)$input->getOption(self::OPTION_USER);
 
         if(!$type) {
             $output->writeln('No Content type given. Abort.');
@@ -63,7 +66,7 @@ class PerformanceListCommand extends ContainerAwareCommand {
         }
 
         $output->writeln(sprintf("Running max. %d tests for %s with measurers %s\n...", $iterations, $type, implode(', ', $measurerNames)));
-        $resultSet = $manager->run($type, $iterations);
+        $resultSet = $manager->run($type, $iterations, $userId);
 
         $output->write("\n<info>Results</info>\n\n");
 

--- a/Services/LoadContentType/AbstractMeasurer.php
+++ b/Services/LoadContentType/AbstractMeasurer.php
@@ -51,7 +51,7 @@ abstract class AbstractMeasurer implements MeasurerInterface {
         }
 
         // save results in object
-        $result->setAvg($total / count($valueObjects));
+        $result->setAvg(empty($valueObjects) ? 0 : $total / count($valueObjects));
         $result->setMin($min);
         $result->setMax($max);
 

--- a/Services/LoadContentType/Measurer/LocationContentServiceMeasurer.php
+++ b/Services/LoadContentType/Measurer/LocationContentServiceMeasurer.php
@@ -41,7 +41,7 @@ class LocationContentServiceMeasurer extends AbstractMeasurer {
     private function load(ValueObject $valueObject)
     {
         $query = new LocationQuery();
-        $query->criterion = new Query\Criterion\ContentId($valueObject->id);
+        $query->filter = new Query\Criterion\ContentId($valueObject->id);
 
         $res = $this->getApiRepository()->getSearchService()->findLocations($query);
 

--- a/Services/LoadContentType/Measurer/SearchContentMeasurer.php
+++ b/Services/LoadContentType/Measurer/SearchContentMeasurer.php
@@ -41,7 +41,7 @@ class SearchContentMeasurer extends AbstractMeasurer {
     private function load(ValueObject $valueObject)
     {
         $query = new Query();
-        $query->criterion = new Query\Criterion\ContentId($valueObject->id);
+        $query->filter = new Query\Criterion\ContentId($valueObject->id);
 
         $this->getApiRepository()->getSearchService()->findContent($query);
     }

--- a/Services/LoadContentType/Measurer/SearchContentWithLanguageFilterMeasurer.php
+++ b/Services/LoadContentType/Measurer/SearchContentWithLanguageFilterMeasurer.php
@@ -41,7 +41,7 @@ class SearchContentWithLanguageFilterMeasurer extends AbstractMeasurer {
     private function load(ValueObject $valueObject)
     {
         $query = new Query();
-        $query->criterion = new Query\Criterion\ContentId($valueObject->id);
+        $query->filter = new Query\Criterion\ContentId($valueObject->id);
 
         // filter for only current! language
         $fieldFilters = array();

--- a/Services/LoadContentType/Measurer/SearchServiceFindContentAsSingleMeasurer.php
+++ b/Services/LoadContentType/Measurer/SearchServiceFindContentAsSingleMeasurer.php
@@ -41,7 +41,7 @@ class SearchServiceFindContentAsSingleMeasurer extends AbstractMeasurer {
     private function load(ValueObject $valueObject)
     {
         $query = new Query();
-        $query->criterion = new Query\Criterion\ContentId($valueObject->id);
+        $query->filter = new Query\Criterion\ContentId($valueObject->id);
 
         $this->getApiRepository()->getSearchService()->findContent($query);
     }

--- a/Services/LoadContentType/Measurer/SearchServiceFindSingleMeasurer.php
+++ b/Services/LoadContentType/Measurer/SearchServiceFindSingleMeasurer.php
@@ -41,9 +41,9 @@ class SearchServiceFindSingleMeasurer extends AbstractMeasurer {
     private function load(ValueObject $valueObject)
     {
         $query = new Query();
-        $query->criterion = new Query\Criterion\ContentId($valueObject->id);
+        $query->filter = new Query\Criterion\ContentId($valueObject->id);
 
-        $this->getApiRepository()->getSearchService()->findSingle($query->criterion);
+        $this->getApiRepository()->getSearchService()->findSingle($query->filter);
     }
 
     /**

--- a/Services/LoadContentType/SingleManager.php
+++ b/Services/LoadContentType/SingleManager.php
@@ -104,8 +104,8 @@ class SingleManager {
     protected function loadContentIdsByType($type, $iterations = 100)
     {
         $query = new Query();
-        $query->criterion = new Query\Criterion\ContentTypeIdentifier($type);
-        $query->limit = $iterations;
+        $query->filter = new Query\Criterion\ContentTypeIdentifier($type);
+        $query->limit = (int)$iterations;
 
         $searchResult = $this->getSearchService()->findContent($query);
         $contentsToFind = array();

--- a/Services/LoadContentType/SingleManager.php
+++ b/Services/LoadContentType/SingleManager.php
@@ -74,13 +74,19 @@ class SingleManager {
      * Then run all injected measurers.
      * Returns an array of Results
      *
-     * @param $contentTypeName
-     * @param $iterations
+     * @param string $contentTypeName
+     * @param int    $iterations
+     * @param int    $userId
      *
      * @return Result[]
      */
-    public function run($contentTypeName, $iterations)
+    public function run($contentTypeName, $iterations, $userId = 0)
     {
+        // set user id if provided
+        if ($userId) {
+            $this->getApiRepository()->setCurrentUser($this->getApiRepository()->getUserService()->loadUser($userId));
+        }
+
         // load value objects to search for
         $valueObjects = $this->loadContentIdsByType($contentTypeName, $iterations);
 
@@ -105,7 +111,7 @@ class SingleManager {
     {
         $query = new Query();
         $query->filter = new Query\Criterion\ContentTypeIdentifier($type);
-        $query->limit = (int)$iterations;
+        $query->limit = $iterations;
 
         $searchResult = $this->getSearchService()->findContent($query);
         $contentsToFind = array();


### PR DESCRIPTION
`criterion` has been deprecated for a while and is removed from 6.0, change bundle to use ->filter instead which was introduced in 5.3.0 in https://github.com/ezsystems/ezpublish-kernel/commit/6e540c579dbe5e556cdfc42e121d10a5817d694e
